### PR TITLE
Rename to Model Epoch when Restoring

### DIFF
--- a/io_utils.py
+++ b/io_utils.py
@@ -81,7 +81,7 @@ def get_resume_file(checkpoint_dir):
     if len(filelist) == 0:
         return None
 
-    filelist =  [ x  for x in filelist if os.path.basename(x) != 'best_model.tar' ]
+    filelist =  [ x  for x in filelist if not os.path.basename(x) in ['best_model.tar', 'last_model.tar'] ]
     epochs = np.array([int(os.path.splitext(os.path.basename(x))[0]) for x in filelist])
     max_epoch = np.max(epochs)
     resume_file = os.path.join(checkpoint_dir, '{:d}.tar'.format(max_epoch))

--- a/wandb_restore.py
+++ b/wandb_restore.py
@@ -23,7 +23,7 @@ checkpoint_dir = os.path.split(args.path)[0]
 if not os.path.exists(checkpoint_dir):
     os.makedirs(checkpoint_dir, exist_ok=True)
 
-model_epoch = torch.load(args.path)["epoch"]
+model_epoch = torch.load(wandb_path.name)["epoch"]
 
 restore_path = os.path.join(checkpoint_dir, f"{model_epoch}.tar")
 

--- a/wandb_restore.py
+++ b/wandb_restore.py
@@ -18,13 +18,17 @@ wandb.init(id=args.id, project="fsl_ssl", resume=True)
 
 wandb_path = wandb.restore(args.path)
 
-if not os.path.exists(os.path.split(args.path)[0]):
-    os.makedirs(os.path.split(args.path)[0], exist_ok=True)
+checkpoint_dir = os.path.split(args.path)[0]
 
-shutil.move(wandb_path.name, args.path)
+if not os.path.exists(checkpoint_dir):
+    os.makedirs(checkpoint_dir, exist_ok=True)
 
-print("Checkpoint restored at ", args.path)
+model_epoch = torch.load(args.path)["epoch"]
 
-print("The model's epoch is ", torch.load(args.path)["epoch"])
+restore_path = os.path.join(checkpoint_dir, f"{model_epoch}.tar")
 
-print("Please rename it to continue training")
+shutil.move(wandb_path.name, restore_path)
+
+print("Checkpoint restored at", restore_path)
+
+print("The model's epoch is", model_epoch)


### PR DESCRIPTION
- Automatically renames model checkpoint to model's epoch.
- Fixed `get_resume_file` when there is `last_model.tar`.